### PR TITLE
Remove AC_CHECK_HEADER_STDBOOL 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -219,7 +219,6 @@ AC_CHECK_HEADERS([stdlib.h string.h sys/time.h])
 #
 # Checks for typedefs, structures, and compiler characteristics.
 #
-AC_CHECK_HEADER_STDBOOL
 AC_C_INLINE
 AC_TYPE_SIZE_T
 


### PR DESCRIPTION
Since neither stdbool.h nor C99 feature used in this library.